### PR TITLE
Enable PCRE2 on rust-ripgrep

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,3 +1,3 @@
 sources:
-  ripgrep-14.1.1-vendor.tar.xz: 759e5ed9f70dd811fe53b13f6ce2f49fd09f3cd1
-  ripgrep-14.1.1.crate: bdc875594d6271e01ad6e128e7ee0bf439a8f2c5
+  ripgrep-14.1.1-vendor.tar.xz: 24fa85b8dbc1806a6c12c05281fe384226f8357f
+  vendor.tar.gz: f3c6ced6ec2394adffca7a931bbfcd3f0e86a2fb

--- a/.abf.yml
+++ b/.abf.yml
@@ -1,3 +1,3 @@
 sources:
-  ripgrep-14.1.1.tar.xz: 24fa85b8dbc1806a6c12c05281fe384226f8357f
+  ripgrep-14.1.1.tar.gz: 24fa85b8dbc1806a6c12c05281fe384226f8357f
   vendor.tar.gz: f3c6ced6ec2394adffca7a931bbfcd3f0e86a2fb

--- a/.abf.yml
+++ b/.abf.yml
@@ -1,3 +1,3 @@
 sources:
-  ripgrep-14.1.1-vendor.tar.xz: 24fa85b8dbc1806a6c12c05281fe384226f8357f
+  ripgrep-14.1.1.tar.xz: 24fa85b8dbc1806a6c12c05281fe384226f8357f
   vendor.tar.gz: f3c6ced6ec2394adffca7a931bbfcd3f0e86a2fb

--- a/ripgrep-fix-metadata.diff
+++ b/ripgrep-fix-metadata.diff
@@ -1,9 +1,0 @@
---- ripgrep-14.1.1/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ ripgrep-14.1.1/Cargo.toml	2025-02-22T20:24:22.972440+00:00
-@@ -183,6 +183,3 @@
- 
- [features]
- pcre2 = ["grep/pcre2"]
--
--[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.jemallocator]
--version = "0.5.0"


### PR DESCRIPTION
PCRE2 is Perl Compatible Regular Expressions. Every other distro has this enabled in their `ripgrep`; OpenMandriva did not, until now. The existing .spec file for this had been grabbed from Fedora and minimally changed, and those changes somehow disabled PCRE2. I refactored this according to a pattern I got from @vuatech, which means not only is PCRE2 enabled, but also the .spec file follows the OpenMandriva pattern much more closely. 
